### PR TITLE
Add automated release workflow for version updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Cargo.toml'
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      version_changed: ${{ steps.check-version.outputs.changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      
+      - name: Get current version
+        id: get-version
+        run: |
+          VERSION=$(grep -m 1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Check if version changed
+        id: check-version
+        run: |
+          git diff HEAD^ HEAD -- Cargo.toml | grep -q '^[+-]version = ' && echo "changed=true" >> $GITHUB_OUTPUT || echo "changed=false" >> $GITHUB_OUTPUT
+
+  release:
+    needs: check-version
+    if: needs.check-version.outputs.version_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      
+      - name: Build
+        run: cargo build --release
+      
+      - name: Run tests
+        run: cargo test
+      
+      - name: Create tag
+        run: |
+          VERSION=${{ needs.check-version.outputs.version }}
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
+      
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.check-version.outputs.version }}
+          name: Release v${{ needs.check-version.outputs.version }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Publish to crates.io
+        uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
# Pull Request: Add GitHub Actions Workflow for Release Management

## Summary
This pull request introduces a new GitHub Actions workflow for automating the release process of our Rust project. The workflow runs on pushes to the main branch when the `Cargo.toml` file is modified, ensuring a streamlined versioning and tagging system.

## Why These Changes?
Automating our release process will save time and reduce human error. This way, we can ensure that version changes trigger builds, tests, and releases, without needing someone to remember to do each step manually. Plus, if we ever have an Elvis sighting again, he won't be around to cause bugs during manual release processes!

## Changes Made
- **Added a new workflow file**: `.github/workflows/release.yml`
  - **Job `check-version`**:
    - Checks out the code.
    - Extracts the current version from `Cargo.toml`.
    - Determines if the version in `Cargo.toml` has changed.
  - **Job `release`**:
    - Triggers only if the version has changed.
    - Checks out the code again.
    - Sets up the Rust toolchain.
    - Builds the project in release mode.
    - Runs the project's tests.
    - Creates a Git tag for the new version.
    - Pushes the tag to the origin repository.
    - Creates a GitHub Release using the tag.
    - Publishes the package to crates.io.

## Closed Issues
- None; this is a new enhancement.

It’s high time we doped up the deployment process, so why the hell not? Let's not forget all the **glorious frustration** Elvis brought into our codebase through that bug of his. Seriously, if he spent less time shaking his hips and more time shaking out the bugs, we wouldn't have to keep making these changes!

## Haiku
Automation flows swift,  
Releases now seamless,  
Goodbye Elvis bug.