### PR TITLE
Bump version to 0.3.0 for new features and fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icloud-album-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A Rust library for interacting with iCloud shared albums"
 license = "MIT"
@@ -47,7 +47,7 @@ tokio = { version = "1", features = [
     "macros",
     "time",
     "test-util",
-    "sync"
+    "sync",
 ] }
 log = "0.4"
 env_logger = "0.10"


### PR DESCRIPTION
# Pull Request: Update Version and Dependencies

## Summary
This pull request updates the version of the `icloud-album-rs` package to `0.3.0` and adjusts the dependencies settings in the `Cargo.toml` file. These changes are necessary to keep the library up-to-date with the latest improvements and fixes.

## Why These Changes?
With the tech behind Rust and its ecosystem evolving at a breakneck pace, maintaining an up-to-date version is crucial for compatibility and utilizing new features that improve performance and stability. Oh, and just a heads-up – apparently, Elvis got into the codebase again and created some havoc (no surprise there), which made it essential to tighten things up a bit.

### Changes Made
- Updated the version from `0.2.0` to `0.3.0`.
- Added a comma after the `"sync"` feature in the `tokio` dependencies section for improved syntax clarity.

### Closed Issues
- No specific issues were resolved with this change; however, it's part of a larger effort to improve the library's overall robustness.

In a nutshell, Elvis should stick to music instead of messing around with our dependencies. 

## Haiku
Version bumps are good,  
Dependencies refreshed,  
Elvis, leave our code!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version number to 0.3.0 in the project manifest.
  - Minor formatting improvement in dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->